### PR TITLE
Make jetty configs vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,10 @@ solr_log_dir: /var/log/solr
 solr_jetty_log_dir: /var/log/jetty
 solr_home: /var/solr
 solr_data_dir: "{{ solr_home }}/data"
+jetty_http_config_template: "jetty-http.xml.j2"
+jetty_config_template: "jetty.xml.j2"
+solr_in_sh_template: "solr.in.sh.j2"
+solr_xml_template: "solr.xml.j2"
 
 # Logs
 solr_log_root_level: WARN

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -26,28 +26,28 @@
 
 - name: SolrCloud | Configuring jetty server
   template:
-    src: "{{ solr_templates_dir }}/jetty.xml.j2"
+    src: "{{ solr_templates_dir }}/{{ jetty_config_template }}"
     dest: "{{ solr_installation_dir }}/server/etc/jetty.xml"
     force: true
   notify: Restart SolrCloud
 
 - name: SolrCloud | Configuring jetty server http
   template:
-    src: "{{ solr_templates_dir }}/jetty-http.xml.j2"
+    src: "{{ solr_templates_dir }}/{{ jetty_http_config_template }}"
     dest: "{{ solr_installation_dir }}/server/etc/jetty-http.xml"
     force: true
   notify: Restart SolrCloud
 
 - name: SolrCloud | Configuring SolrCloud init script
   template:
-    src: "{{ solr_templates_dir }}/solr.in.sh.j2"
+    src: "{{ solr_templates_dir }}/{{ solr_in_sh_template }}"
     dest: /etc/default/solr.in.sh
     force: true
   notify: Restart SolrCloud
 
 - name: SolrCloud | Configuring SolrCloud properties
   template:
-    src: "{{ solr_templates_dir }}/solr.xml.j2"
+    src: "{{ solr_templates_dir }}/{{ solr_xml_template }}"
     dest: "{{ solr_data_dir }}/solr.xml"
     force: true
   notify: Restart SolrCloud


### PR DESCRIPTION
Want to be able to override these with templates in playbook so we can modify Jetty server configurations more readily (like forcnig HTTP/2).