### PR TITLE
Use 302 instead of 200 for status check.

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -84,9 +84,9 @@
 - name: SolrCloud | Wait for SolrCloud to fully startup before continue
   uri:
     url: "http://{{ solr_host }}:{{ solr_port }}/solr"
-    status_code: 200
+    status_code: 302
   retries: "100"
   delay: "1"
   register: result
-  until: result.status == 200
+  until: result.status == 302
   changed_when: false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -83,10 +83,10 @@
 
 - name: SolrCloud | Wait for SolrCloud to fully startup before continue
   uri:
-    url: "http://{{ solr_host }}:{{ solr_port }}/solr"
-    status_code: 302
+    url: "http://{{ solr_host }}:{{ solr_port }}/solr/admin/collections?action=LIST"
+    status_code: 200
   retries: "100"
   delay: "1"
   register: result
-  until: result.status == 302
+  until: result.status == 200
   changed_when: false


### PR DESCRIPTION
http://solr:8983/solr returns 302 not 200

Our status check thus fails because 200 is never returned.

This commit changes the status check to look for 302 instead of 200.